### PR TITLE
Pyhton 3 fixes

### DIFF
--- a/src/fstabViewer.py
+++ b/src/fstabViewer.py
@@ -12,7 +12,7 @@ from Screens.MessageBox import MessageBox
 from Screens.Screen import Screen
 from Screens.ChoiceBox import ChoiceBox
 from Tools.Directories import fileExists
-from dirSelect import dirSelectDlg
+from .dirSelect import dirSelectDlg
 from enigma import RT_HALIGN_LEFT, RT_HALIGN_RIGHT, eListboxPythonMultiContent, gFont
 import os
 import skin
@@ -133,12 +133,12 @@ class fstabViewerScreen(Screen, HelpableScreen):
 			self.session.openWithCallback(self.writeFile, fstabEditorScreen, selectedEntry=self.selectedEntry)
 
 	def buildScreen(self):
+		global entryList, lenghtList
 		self.fstabEntryList = []
 		entryList = []
 		lengthList = [0, 0, 0, 0]
 		if fileExists("/etc/fstab"):
 			fstabFile = open("/etc/fstab", "r")
-			global entryList, lenghtList
 			self.counter = 0
 			for line in fstabFile:
 				if line[0] != "\n" and line[0] != "#":
@@ -377,7 +377,7 @@ class fstabEditorScreen(Screen, ConfigListScreen, HelpableScreen):
 			entryList[self.selectedEntry] = new_entry
 		try:
 			if not os.path.exists(self.mountpoint.value):
-				os.mkdir(self.mountpoint.value, 0755)
+				os.mkdir(self.mountpoint.value, 0o755)
 		except:
 			pass
 		self.close(1)

--- a/src/plugin.py
+++ b/src/plugin.py
@@ -22,7 +22,7 @@ import fcntl
 import os
 from time import sleep
 from re import search
-import fstabViewer
+from . import fstabViewer
 
 plugin_version = "2.8"
 
@@ -582,7 +582,7 @@ class DevicesMountPanel(Screen, ConfigListScreen):
 				devicemount = device[-5:]
 				mountdir = '/media/%s' % (devicemount)
 				if not os.path.exists(mountdir):
-					os.mkdir(mountdir, 0755)
+					os.mkdir(mountdir, 0o755)
 				system('mount ' + device + ' /media/%s' % (devicemount))
 				mountok = False
 				f = open('/proc/mounts', 'r')
@@ -730,7 +730,7 @@ class DevicesMountPanel(Screen, ConfigListScreen):
 			self.device_uuid_tmp = self.device_uuid_tmp.replace('\n', "")
 			self.device_uuid = 'UUID=' + self.device_uuid_tmp
 			if not os.path.exists(self.mountp):
-				os.mkdir(self.mountp, 0755)
+				os.mkdir(self.mountp, 0o755)
 			flashexpander = None
 			if fileExists("/usr/lib/enigma2/python/Plugins/Extensions/Flashexpander/plugin.pyo") and fileExists("/usr/lib/enigma2/python/Plugins/Extensions/Flashexpander/flashexpander.pyo"):
 				try:
@@ -1331,7 +1331,7 @@ class DeviceMountPanelConf(Screen, ConfigListScreen):
 			self.device_uuid_tmp = self.device_uuid_tmp.replace('\n', "")
 			self.device_uuid = 'UUID=' + self.device_uuid_tmp
 			if not os.path.exists(self.mountp):
-				os.mkdir(self.mountp, 0755)
+				os.mkdir(self.mountp, 0o755)
 			flashexpander = None
 			if fileExists("/usr/lib/enigma2/python/Plugins/Extensions/Flashexpander/plugin.pyo") and fileExists("/usr/lib/enigma2/python/Plugins/Extensions/Flashexpander/flashexpander.pyo"):
 				try:


### PR DESCRIPTION
-Fix imports.
-use '0o' prefix for octal numbers.
-Fix 'used prior to global declaration'.

Compatible with Python 2.